### PR TITLE
Change web application port

### DIFF
--- a/.auth0/lab/environment.json
+++ b/.auth0/lab/environment.json
@@ -11,7 +11,7 @@
         "ISSUER_BASE_URL": "$tenant_base_url",
         "CLIENT_ID": "$client_id",
         "SESSION_SECRET": "a long, randomly-generated string stored in env",
-        "PORT": 7000
+        "PORT": 7777
       }
     }
   ]

--- a/.auth0/lab/guides/add-authentication-to-the-expenses-web-application.tour
+++ b/.auth0/lab/guides/add-authentication-to-the-expenses-web-application.tour
@@ -165,7 +165,7 @@
     },
     {
       "file": "src/web-app/index.js",
-      "description": "## Enable Global Authentication Routing\nHere, we'll add code to the application that configures the middleware to make authentication optional across the entire application. In the app.use configuration block that we added previously, we'll add:\n\n``` jsx\n\nauthRequired: false,\n```\nto make this change.\n\\\n&nbsp;\n\\\nWith this done, all routes are public again. We'll need a way to explicitly make certain routes private. Thankfully, this functionality is supplied by the same express-openid-connect middleware! ",
+      "description": "## Enable Global Authentication Routing\nHere, we'll add code to the application that configures the middleware to make authentication optional across the entire application. In the app.use configuration block that we added previously, we'll add:\n\n``` jsx\n\n        authRequired: false,\n```\nto make this change.\n\\\n&nbsp;\n\\\nWith this done, all routes are public again. We'll need a way to explicitly make certain routes private. Thankfully, this functionality is supplied by the same express-openid-connect middleware! ",
       "line": 48,
       "selection": {
         "start": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
     "humao.rest-client",
   ],
   "forwardPorts": [
-    7000, //Web App
+    7777, //Web App
   ],
   "shutdownAction": "stopCompose",
   "postStartCommand": "npm run init",

--- a/src/web-app/env-config.js
+++ b/src/web-app/env-config.js
@@ -4,7 +4,7 @@ const {
   CLIENT_ID,
   CLIENT_SECRET,
   SESSION_SECRET = 'a long, randomly-generated string stored in env',
-  PORT = 7000,
+  PORT = 7777,
 } = process.env;
 
 const appUrl = `http://localhost:${PORT}`;

--- a/src/web-app/package.json
+++ b/src/web-app/package.json
@@ -17,7 +17,7 @@
     "start": "PORT=$npm_package_config_port SESSION_SECRET=$npm_package_config_session_secret node index"
   },
   "config": {
-    "port": 7000,
+    "port": 7777,
     "session_secret": "a long, randomly-generated string stored in env"
   },
   "keywords": [


### PR DESCRIPTION
### Description

- This PR changes the web application port used locally, the original port `7000` is already used by Control Center / Airtunes on MacOS 12.1 (Monterey). The proposed port `7777` seems to be free on a default install.

- fix indentation of a CodeTour snippet

### References

<https://developer.apple.com/forums/thread/682332>

### Testing

- [x] Tested locally on MacOS 12.1

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
