### PR TITLE
Use Auth Code Flow

### DIFF
--- a/.auth0/lab/guides/add-authentication-to-the-expenses-web-application.tour
+++ b/.auth0/lab/guides/add-authentication-to-the-expenses-web-application.tour
@@ -25,7 +25,7 @@
     },
     {
       "file": "src/web-app/index.js",
-      "description": "## Configure the App to use the Authentication Middleware\nIn order for our application to use the auth middleware to route requests, it must be supplied with certain keys. Let's add the necessary code, below, then walk through each of the required keys.\n\n``` jsx\n\napp.use(\n    auth({\n        secret: SESSION_SECRET,\n        auth0Logout: true,\n        baseURL: APP_URL,\n        issuerBaseURL: ISSUER_BASE_URL,\n        clientID: CLIENT_ID,\n    })\n);\n\n```\n to add it to the application.",
+      "description": "## Configure the App to use the Authentication Middleware\nIn order for our application to use the auth middleware to route requests, it must be supplied with certain keys. Let's add the necessary code, below, then walk through each of the required keys.\n\n``` jsx\n\napp.use(\n    auth({\n        authorizationParams: {\n            response_type: 'code',\n        },\n        secret: SESSION_SECRET,\n        auth0Logout: true,\n        baseURL: APP_URL,\n        issuerBaseURL: ISSUER_BASE_URL,\n        clientID: CLIENT_ID,\n    })\n);\n\n```\n to add it to the application.",
       "line": 40,
       "selection": {
         "start": {


### PR DESCRIPTION
This just adds the `response_type` param to the AuthZ server to request the Auth Code Grant type to the CodeTour step #3 (Tour 2). But we probably need an explanation about what this param does. Should we start out without passing this param to the middleware? Then we can have the learner log in to the Expenses app and see we get an ID token but no Access token because we're using the Implicit Grant. Reveal that we'd need to use the Auth Code Grant in order to get an Access token and add that to the middleware. We can also show learners how to change the App config to only accept the Auth Code Grant (and uncheck Implicit).

Closes #14 